### PR TITLE
Feature: Compare Page Token Search -Autocomplete

### DIFF
--- a/REVIEW_NOTES_AUTOCOMPLETE.md
+++ b/REVIEW_NOTES_AUTOCOMPLETE.md
@@ -1,0 +1,44 @@
+# Review Notes: Compare Page Token Autocomplete
+
+**Branch:** `nicho/frontend-updates` (Consider renaming to `nicho/compare-page-autocomplete` for clarity before sharing if desired)
+
+**Purpose of these Changes:**
+This set of changes implements an autocomplete/suggestion feature for the token name input fields on the `/compare` page. As the user types into either "Token 1 Name" or "Token 2 Name" input, a dropdown list of matching tokens (by name or symbol) will appear, allowing the user to easily select a token.
+
+**Files Modified:**
+
+1.  **`app/compare/page.tsx`**:
+    *   **State Management:** Added new state variables (`token1Suggestions`, `token2Suggestions`, `showToken1Suggestions`, `showToken2Suggestions`) to manage the suggestion lists and their visibility.
+    *   **Search Logic:**
+        *   Modified `handleTokenSearch` to filter the `allTokens` array based on user input (matches name or symbol, case-insensitive, shows top 5).
+        *   Added `handleSuggestionClick` to populate the input field when a suggestion is clicked and hide the dropdown.
+    *   **UI Rendering:**
+        *   Input fields (`#token1`, `#token2`) now trigger the updated search logic.
+        *   `onFocus` handlers added to inputs to potentially reshow suggestions.
+        *   `autoComplete="off"` added to inputs.
+        *   Conditionally rendered `div` elements below each input to display the suggestion list. These are styled with Tailwind CSS for basic appearance (background, border, hover effects, max height, and scroll).
+        *   Parent `div`s of inputs were made `relative` to correctly position the absolute suggestion dropdowns.
+    *   **Temporary Mock Data for Testing:**
+        *   A `dummyAllTokens` array was added directly in the component.
+        *   The `useEffect` hook that fetches tokens was temporarily modified to use this `dummyAllTokens` data instead of calling `/api/tokens`. This was done to allow local testing of the UI.
+        *   **IMPORTANT:** This mock data setup (`dummyAllTokens` and the modified `useEffect`) should be reverted or made conditional (e.g., `process.env.NODE_ENV === 'development'`) before merging to production or if the `/api/tokens` endpoint is functional in the test/staging environment. The original `fetchTokens` logic is commented out within the `useEffect` for easy restoration.
+    *   **Styling Fix (Dropdown Visibility):**
+        *   The `z-index` of the suggestion dropdowns was increased from `z-10` to `z-50` (in `app/compare/page.tsx`). This was an initial attempt to fix the dropdown being cut off.
+
+2.  **`app/globals.css`**:
+    *   **Dropdown Cutoff Fix:** The primary fix for the dropdown being cut off was made here. The `overflow: hidden;` property was commented out from the `.card-with-border` CSS class. This class is used by the `DashcoinCard` component, which was clipping the absolutely positioned suggestion dropdown.
+
+**To Test:**
+1.  Ensure your local development server is running.
+2.  Navigate to the `/compare` page.
+3.  Start typing into either of the token name input fields (e.g., "Bit", "Sol", "Dash", "Test" based on the current dummy data).
+4.  A dropdown list of suggestions should appear.
+5.  Clicking a suggestion should populate the input.
+6.  The suggestion list should now be fully visible and not cut off by the card container.
+
+**Areas for Further Consideration (Optional Follow-ups):**
+*   **Click Outside to Close Dropdown:** Currently, the dropdown closes on selection or when the input is cleared. Implementing a "click outside" to close behavior would be a good UX improvement.
+*   **Keyboard Navigation:** For accessibility, adding up/down arrow key navigation within the suggestion list and using Enter to select.
+*   **Debouncing:** If `allTokens` were very large and fetched frequently, debouncing the search might be needed, but it's likely fine with the current client-side filtering approach.
+
+Please review the changes for correctness, adherence to coding standards, and potential integration issues. Pay special attention to the temporary mock data setup in `app/compare/page.tsx` and ensure it's handled appropriately before production. 


### PR DESCRIPTION
This PR adds an autocomplete feature to the token search inputs on the compare page. 

Please see REVIEW_NOTES_AUTOCOMPLETE.md in this branch for a detailed breakdown of changes and testing instructions. Key items: new UI for suggestions, temporary mock data in app/compare/page.tsx for testing (this needs to be removed/reverted before merging to prod).